### PR TITLE
Only show available topics

### DIFF
--- a/src/context/org.js
+++ b/src/context/org.js
@@ -2,17 +2,7 @@ import React, { createContext, useEffect, useState } from 'react'
 
 export const Context = createContext(undefined)
 export const Provider = ({ value: { apiHost, organizationId }, children }) => {
-  const [topics, setTopics] = useState([])
   const [config, setConfig] = useState({})
-
-  const getTopics = async () => {
-    return await fetch(`${apiHost}/api/topics`, {
-      method: 'POST',
-      body: JSON.stringify({
-        organizationId
-      })
-    }).then((res) => res.json())
-  }
 
   const getConfig = async () => {
     return await fetch(`${apiHost}/api/config`, {
@@ -24,16 +14,13 @@ export const Provider = ({ value: { apiHost, organizationId }, children }) => {
   }
 
   useEffect(() => {
-    getTopics().then((topics) => {
-      setTopics(topics)
-    })
     getConfig().then((config) => {
       setConfig(config)
     })
   }, [])
 
   return (
-    <Context.Provider value={{ apiHost, organizationId, topics, config }}>
+    <Context.Provider value={{ apiHost, organizationId, config }}>
       {children}
     </Context.Provider>
   )


### PR DESCRIPTION
Previously we were showing all topics regardless of whether the page questions contained them or not.

Closes #47
